### PR TITLE
Implement GitHub Actions for Snapcraft Build

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,20 @@
+name: Snapcraft
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Snapcraft Build
+    steps:
+    - uses: actions/checkout@v3
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v3
+      with:
+        name: snap
+        path: ${{ steps.snapcraft.outputs.snap }}
+    - run: |
+        sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,8 +75,8 @@ layout:
     bind: $SNAP/usr/local/share
   /usr/share/X11:
     bind: $SNAP/usr/share/X11
-  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gtk-2.0/modules:
-    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gtk-2.0/modules
+  /usr/lib/$CRAFT_ARCH_TRIPLET/gtk-2.0/modules:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gtk-2.0/modules
 
 apps:
   sanmill:
@@ -123,14 +123,14 @@ parts:
       - libqt5widgets5
       - libqt5multimedia5
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       chmod +x ./version.sh
       ./version.sh
     override-build: |
-      cmake ${SNAPCRAFT_PART_BUILD}/../src/src/ui/qt -DCMAKE_BUILD_TYPE=Release
+      cmake ${CRAFT_PART_BUILD}/../src/src/ui/qt -DCMAKE_BUILD_TYPE=Release
       make -j $(nproc)
-      mkdir -p ${SNAPCRAFT_PART_INSTALL}/usr/local/bin
-      cp ./mill-pro ${SNAPCRAFT_PART_INSTALL}/usr/local/bin/
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp ./mill-pro ${CRAFT_PART_INSTALL}/usr/local/bin/
 
   desktop-qt5:
       source: https://github.com/ubuntu/snapcraft-desktop-helpers.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,6 +122,10 @@ parts:
       - libqt5core5a
       - libqt5widgets5
       - libqt5multimedia5
+    override-pull: |
+      snapcraftctl pull
+      chmod +x ./version.sh
+      ./version.sh
     override-build: |
       cmake ${SNAPCRAFT_PART_BUILD}/../src/src/ui/qt -DCMAKE_BUILD_TYPE=Release
       make -j $(nproc)


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow that triggers on pushes to the main branch. It automates the process of building the snap package using Snapcraft in an Ubuntu environment. The workflow includes steps to checkout the code, build the snap package using Snapcraft, upload the built snap as a GitHub Actions artifact, and install and test the snap package. With this automated workflow, we ensure the snap package is always built and tested with the latest changes in the master branch, further enhancing the development and delivery process. 

This PR also modifies the snapcraft.yaml file to run the version.sh script before the build phase by adding the script execution in the 'override-pull' hook. The version.sh script is responsible for updating the version number, which is subsequently displayed in the About dialog of the built program. Without this change, the About dialog would only display the build time.